### PR TITLE
アクセサを使ってデータの値を加工する

### DIFF
--- a/app/Task.php
+++ b/app/Task.php
@@ -6,5 +6,25 @@ use Illuminate\Database\Eloquent\Model;
 
 class Task extends Model
 {
-    //
+    // statusのlabelの値を文字列への変更し定義
+    const STATUS = [
+        1 => [ 'label' => '未着手'],
+        2 => [ 'label' => '着手中'],
+        3 => [ 'label' => '完了'],
+    ];
+
+    // statusの文字列を取得するためのメソッド
+    public function getStatusLabelAttribute()
+    {
+        // statusカラムの値を取得
+        $status = $this->attributes['status'];
+
+        // isset関数で変数に値が入っているかをチェックする
+        if (!isset(self::STATUS[$status])) {
+            return ''; //　空だった場合は空文字を返す
+        }
+
+        // statusカラムの値へアクセス
+        return self::STATUS[$status]['label'];
+    }
 }

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -64,7 +64,8 @@
                   <!-- コントローラーからシーダーに登録されたデータを取得し、ブラウザに表示する -->
                   <td>{{ $task->title }}</td>
                   <td>
-                    <span class="label">{{ $task->status }}</span> <!-- タスクの進捗状況 -->
+                    <!-- アクセサメソッドを参照するときは文字の区切りがアンダースコアになる -->
+                    <span class="label">{{ $task->status_label }}</span> <!-- タスクの進捗状況 -->
                   </td>
                   <td>{{ $task->due_date }}</td>
                   <td><a href="#">編集</a></td>


### PR DESCRIPTION
タスクの状態に表示されるデータを数値ではなく文字列に変換するため、アクセサを利用してタスクモデルのデータを加工し、モデルクラスから疑似的なプロパティとして値を参照する。
![スクリーンショット (3)](https://user-images.githubusercontent.com/61861236/78753604-03507c00-79b1-11ea-8e8b-e0662181a4f3.png)
少し分かりにくいため、変更した部分を赤丸で囲んでおきました。
