### PR TITLE
タスクの日付表示形式を変更する

### DIFF
--- a/app/Task.php
+++ b/app/Task.php
@@ -3,6 +3,8 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+// Carbonを使うためuse宣言
+use Carbon\Carbon;
 
 class Task extends Model
 {
@@ -42,5 +44,14 @@ class Task extends Model
 
         // statusカラムの値へアクセス
         return self::STATUS[$status]['class'];
+    }
+
+    // 日付の表示形式を変更するためのメソッド
+    public function getFormattedDueDateAttribute()
+    {
+        // Carbon(日時操作ライブラリ)を使って表示されるフォーマットを変更
+        return Carbon::createFromFormat('Y-m-d', $this->attributes['due_date'])
+            // ハイフン区切りからスラッシュ区切りに変更
+            ->format('Y/m/d');
     }
 }

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -68,7 +68,8 @@
                     <!-- ラベル部分のクラス属性を追加 -->
                     <span class="label {{ $task->status_class }}">{{ $task->status_label }}</span> <!-- タスクの進捗状況 -->
                   </td>
-                  <td>{{ $task->due_date }}</td>
+                  <!-- 日付変更のメソッドを参照 -->
+                  <td>{{ $task->formatted_due_date }}</td>
                   <td><a href="#">編集</a></td>
                 </tr>
               @endforeach


### PR DESCRIPTION
タスクモデルにgetFormattedDueDateAttributeメソッドを追記して、Carbonを使ってタスクの日付表示のフォーマットをハイフン区切りからスラッシュ区切りへ変更する。
![スクリーンショット (5)](https://user-images.githubusercontent.com/61861236/78763950-cf7d5280-79c0-11ea-9ee9-5c59e8a8bfa3.png)
