### PR TITLE
フォルダを作成するルートを実装する

### DIFF
--- a/app/Http/Controllers/FolderController.php
+++ b/app/Http/Controllers/FolderController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers;
 
+use App\Folder; 
+// クラスのインポート
 use Illuminate\Http\Request;
 
 class FolderController extends Controller
@@ -10,5 +12,24 @@ class FolderController extends Controller
     public function showCreateForm()
     {
         return view('folders/create');
+    }
+
+    // 引数にインポートしたRequestクラスを受け入れる
+    public function create(Request $request)
+    {
+        // フォルダモデルのインスタンスを作成
+        $folder = new Folder();
+        // タイトルに入力値を代入する
+        // リクエストクラスのインスタンスにリクエストヘッダや送信元IP、フォームの入力値などが入っている
+        $folder->title = $request->title;
+        // インスタンスの状態をデータベースへ書き込む
+        $folder->save();
+        /** 
+         * フォルダを作成するルートに画面の出力は必要ないので、フォルダに対応するタスク一覧画面に
+         * redirectメソッドを呼び出し偏移させる
+         */
+        return redirect()->route('tasks.index', [
+            'id' => $folder->id,
+        ]);
     }
 }

--- a/resources/views/folders/create.blade.php
+++ b/resources/views/folders/create.blade.php
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge"> <!-- IEのバージョンごとに表示崩れがしないよう、各バージョンのモードでレンダリングする -->
+  <title>ToDo App</title>
+  <link rel="stylesheet" href="/css/styles.css">
+</head>
+<body>
+  <header>
+    <nav class="my-navbar">
+      <a class="my-navbar-brand" href="/">ToDo App</a>
+    </nav>
+  </header>
+  <main>
+    <div class="container">
+      <div class="row">
+        <div class="col col-md-offset-3 col-md-6">
+          <nav class="panel panel-default">
+            <div class="panel-heading">フォルダを追加する</div>
+            <div class="panel-body">
+            　<!-- formアクションでurlを呼び出し、フォームを使ってデータを送る -->
+              <form action="{{ route('folders.create') }}" method="post"> 
+              　<!-- 他サイトからの悪意あるPOSTリクエストを受け付けないよう、自分のサイトからのPOSTリクエストだけ受け付けるため、CSRFトークンを用いる -->
+                @csrf 
+                <div class="form-group">
+                  <label for="title">フォルダ名</label>
+                  <input type="text" class="form-control" name="title" id="title" />
+                </div>
+                <div class="text-right">
+                  <button type="submit" class="btn btn-primary">送信</button>
+                </div>
+              </form>
+            </div>
+          </nav>
+        </div>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -20,7 +20,8 @@
         <nav class="panel panel-default">
           <div class="panel-heading">フォルダ</div>
           <div class="panel-body">
-            <a href="#" class="btn btn-default btn-block">
+            <!-- フォルダ作成画面へのリンクを埋める -->
+            <a href="{{ route('folders.create') }}" class="btn btn-default btn-block">
               フォルダを追加する
             </a>
           </div>

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>ToDo App</title>
-  <link rel="stylesheet" href="../../css/styles.css">
+  <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body>
 <header>

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,6 +22,6 @@ Auth::routes();
 Route::get('/folders/{id}/tasks', 'TaskController@index')->name('tasks.index');
 
 // フォルダ作成ページを表示する
-Route::post('/folders/create', 'FolderController@showCreateForm')->name('folders.create'); // 名前付きルートを使うことでURLを一括変更できる
+Route::get('/folders/create', 'FolderController@showCreateForm')->name('folders.create'); // 名前付きルートを使うことでURLを一括変更できる
 // フォルダ作成処理を実行する
 Route::post('/folders/create', 'FolderController@create'); // 同じURLでHTTPメソッド違いのルートがいくつかある場合、どれか一つに名前をつければいい


### PR DESCRIPTION
フォルダコントローラーを修正し、Requestクラスのインスタンスからフォームの入力値を取得し、saveメソッドを使ってモデルクラスにプロパティとして代入された値を、モデルクラスが表すテーブルの各カラムに書き込む。
ブラウザで確認するため、トレーニングフォルダを追加しました。
![スクリーンショット (12)](https://user-images.githubusercontent.com/61861236/78962715-f5753500-7b2f-11ea-9fd3-fe1d729f3de0.png)
![スクリーンショット (13)](https://user-images.githubusercontent.com/61861236/78962719-f7d78f00-7b2f-11ea-92e7-fd568653891c.png)

もう一点、タスク一覧画面からフォルダ作成画面にリンクできるように、hrefを修正いたしました。
><a href="{{ route('folders.create') }}" class="btn btn-default btn-block">

