### PR TITLE
フォルダ作成機能の入力値にバリデーション機能を加える

### DIFF
--- a/app/Http/Controllers/FolderController.php
+++ b/app/Http/Controllers/FolderController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers;
 use App\Folder; 
 // クラスのインポート
 use Illuminate\Http\Request;
+// CreateFolderクラスのインポート
+use App\Http\Requests\CreateFolder;
 
 class FolderController extends Controller
 {
@@ -14,13 +16,19 @@ class FolderController extends Controller
         return view('folders/create');
     }
 
-    // 引数にインポートしたRequestクラスを受け入れる
-    public function create(Request $request)
+    /**
+     * 引数をCreateFolderに変更する
+     * FormRequestクラスは先ほどまで指定していたRequestクラスと互換性がある
+     * 入力値の取得などの機能を維持したまま、バリデーション機能を追加できる
+     */
+    public function create(CreateFolder $request)
     {
         // フォルダモデルのインスタンスを作成
         $folder = new Folder();
-        // タイトルに入力値を代入する
-        // リクエストクラスのインスタンスにリクエストヘッダや送信元IP、フォームの入力値などが入っている
+        /** 
+         * タイトルに入力値を代入する
+         * リクエストクラスのインスタンスにリクエストヘッダや送信元IP、フォームの入力値などが入っている
+         */
         $folder->title = $request->title;
         // インスタンスの状態をデータベースへ書き込む
         $folder->save();

--- a/app/Http/Requests/CreateFolder.php
+++ b/app/Http/Requests/CreateFolder.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+// バリデーションをつかさどるFormRequestクラスを作成
+class CreateFolder extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+
+    // 認証関係の処理を行うメソッドなので、特にない場合は常にtrueを返しておく
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+
+    /**
+     * 入力欄ごとにチェックするルールを定義し、ruleメソッドが返す配列がルールを表す
+     * 配列のキーが入力欄になり、HTML側のinput要素のname属性に対応する
+     * titleに、必須入力を表すrequiredを指定している
+     */ 
+    public function rules()
+    {
+        return [
+            'title' => 'required',
+        ];
+    }
+}


### PR DESCRIPTION
フォルダ作成の際、空の入力値や不正のデータが含まれないよう、データベースに書き込む前に入力値をチェックするため、バリデーション機能を追加する。
バリデーションを司るFormRequestクラスを作成し、ruleメソッドを使って入力欄ごとにチェックするルールを定義する。
フォルダコントローラーにCreateFolderクラスをインポートし、バリデーション機能を有効にする。