### PR TITLE
バリデーションのルール違反によるエラーメッセージの表示

### DIFF
--- a/resources/views/folders/create.blade.php
+++ b/resources/views/folders/create.blade.php
@@ -20,6 +20,17 @@
           <nav class="panel panel-default">
             <div class="panel-heading">フォルダを追加する</div>
             <div class="panel-body">
+              <!-- ルール違反の内容が詰められた$errors変数を使ってルール違反があったかを確認する -->
+              @if($errors->any())
+                <div class="alert alert-danger">
+                  <ul>
+                    <!-- ルール違反があった場合、エラーメッセージを列挙する -->
+                    @foreach($errors->all() as $message)
+                      <li>{{ $message }}</li>
+                    @endforeach
+                  </ul>
+                </div>
+              @endif
             　<!-- formアクションでurlを呼び出し、フォームを使ってデータを送る -->
               <form action="{{ route('folders.create') }}" method="post"> 
               　<!-- 他サイトからの悪意あるPOSTリクエストを受け付けないよう、自分のサイトからのPOSTリクエストだけ受け付けるため、CSRFトークンを用いる -->


### PR DESCRIPTION
バリデーションチェックの結果ルール違反が起こると自動的に入力画面にリダイレクトされる。その際エラーの内容をブラウザに表示させるため、テンプレートに処理を追加する。
![スクリーンショット (14)](https://user-images.githubusercontent.com/61861236/78971708-21e87b80-7b47-11ea-835f-8fa320e2fd0b.png)
タイトルに何も入力せずフォルダを作成したところ、エラーメッセージがブラウザに表示されました。