### PR TITLE
フォルダ名入力時の上限文字数ルールを追加する

### DIFF
--- a/app/Http/Requests/CreateFolder.php
+++ b/app/Http/Requests/CreateFolder.php
@@ -33,7 +33,11 @@ class CreateFolder extends FormRequest
     public function rules()
     {
         return [
-            'title' => 'required',
+            /**
+             * titleカラム定義のVARCHAR(20)に合わせて、上限文字数ルールを追加する 
+             * max:20が入力上限数値を表し、複数のルールは | で区切る
+             */ 
+            'title' => 'required|max:20',
         ];
     }
 

--- a/resources/lang/jp/validation.php
+++ b/resources/lang/jp/validation.php
@@ -79,7 +79,8 @@ return [
     'max' => [
         'numeric' => 'The :attribute may not be greater than :max.',
         'file' => 'The :attribute may not be greater than :max kilobytes.',
-        'string' => 'The :attribute may not be greater than :max characters.',
+        // 入力上限数値のエラーメッセージを日本語に変える
+        'string' => ':attribute は :max 文字以内で入力してください。',
         'array' => 'The :attribute may not have more than :max items.',
     ],
     'mimes' => 'The :attribute must be a file of type: :values.',


### PR DESCRIPTION
フォルダテーブルのtitleカラムに定義されたVARCHAR(20)になぞってフォルダ名入力時の文字数上限ルール（20文字以下）を追加する。
さらに21文字以上入力した場合のエラーメッセージを日本語化する。
![スクリーンショット (19)](https://user-images.githubusercontent.com/61861236/79061401-f1c9e580-7cca-11ea-836d-f3d4f46b7799.png)
![スクリーンショット (20)](https://user-images.githubusercontent.com/61861236/79061402-f393a900-7cca-11ea-9137-2ded2cc3b0ae.png)
ブラウザで確認したところ、無事表示されました。
