### PR TITLE
入力エラーでフォーム画面に戻ってきたとき入力値の復元

### DIFF
--- a/app/Http/Requests/CreateFolder.php
+++ b/app/Http/Requests/CreateFolder.php
@@ -33,7 +33,11 @@ class CreateFolder extends FormRequest
     public function rules()
     {
         return [
-            'title' => 'required',
+            /**
+             * titleカラム定義のVARCHAR(20)に合わせて、上限文字数ルールを追加する 
+             * max:20が入力上限数値を表し、複数のルールは | で区切る
+             */ 
+            'title' => 'required|max:20',
         ];
     }
 

--- a/resources/lang/jp/validation.php
+++ b/resources/lang/jp/validation.php
@@ -79,7 +79,8 @@ return [
     'max' => [
         'numeric' => 'The :attribute may not be greater than :max.',
         'file' => 'The :attribute may not be greater than :max kilobytes.',
-        'string' => 'The :attribute may not be greater than :max characters.',
+        // 入力上限数値のエラーメッセージを日本語に変える
+        'string' => ':attribute は :max 文字以内で入力してください。',
         'array' => 'The :attribute may not have more than :max items.',
     ],
     'mimes' => 'The :attribute must be a file of type: :values.',

--- a/resources/views/folders/create.blade.php
+++ b/resources/views/folders/create.blade.php
@@ -37,7 +37,8 @@
                 @csrf 
                 <div class="form-group">
                   <label for="title">フォルダ名</label>
-                  <input type="text" class="form-control" name="title" id="title" />
+                  <!-- 入力エラーでフォーム画面に戻ったとき、old関数からセッション値を取得し、入力欄の値を復元させる -->
+                  <input type="text" class="form-control" name="title" id="title" value="{{ old('title') }}" />
                 </div>
                 <div class="text-right">
                   <button type="submit" class="btn btn-primary">送信</button>


### PR DESCRIPTION
フォルダ作成で入力エラーが起きた際、フォーム画面が戻ると入力値が消えていたので、入力欄の値を復元する。テンプレート folders/create.blade.php のタイトル入力欄の input 要素に value 属性を追加し、old('title') の実行結果を展開する。入力エラー時にセッションに一時的に保存された入力値をold 関数を使って取得する。
![スクリーンショット (21)](https://user-images.githubusercontent.com/61861236/79066692-f4d9cb80-7cf4-11ea-9235-b22c2f6c833f.png)
![スクリーンショット (22)](https://user-images.githubusercontent.com/61861236/79066693-f60af880-7cf4-11ea-885c-8e605bc21bd6.png)
ブラウザで表示したところ、エラーが起きても入力欄の値が残ったままフォーム画面に戻ることが確認できました。