### PR TITLE
タスク作成フォームのルーティングを設定しコントローラーメソッドの引数で受け取る

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -28,4 +28,13 @@ class TaskController extends Controller
             'tasks' => $tasks,
         ]);
     }
+
+    // 入力フォームを表示するためのルートを実装する 
+    public function showCreateForm(int $id) 
+    { 
+        // URL（/folders/{id}/tasks/create）を作るためのフォルダIDをの引数で受け取る 
+        return view('tasks/create', [
+             'folder_id' => $id
+        ]); 
+    }
 }

--- a/app/Http/Requests/CreateFolder.php
+++ b/app/Http/Requests/CreateFolder.php
@@ -33,7 +33,11 @@ class CreateFolder extends FormRequest
     public function rules()
     {
         return [
-            'title' => 'required',
+            /**
+             * titleカラム定義のVARCHAR(20)に合わせて、上限文字数ルールを追加する 
+             * max:20が入力上限数値を表し、複数のルールは | で区切る
+             */ 
+            'title' => 'required|max:20',
         ];
     }
 

--- a/resources/lang/jp/validation.php
+++ b/resources/lang/jp/validation.php
@@ -79,7 +79,8 @@ return [
     'max' => [
         'numeric' => 'The :attribute may not be greater than :max.',
         'file' => 'The :attribute may not be greater than :max kilobytes.',
-        'string' => 'The :attribute may not be greater than :max characters.',
+        // 入力上限数値のエラーメッセージを日本語に変える
+        'string' => ':attribute は :max 文字以内で入力してください。',
         'array' => 'The :attribute may not have more than :max items.',
     ],
     'mimes' => 'The :attribute must be a file of type: :values.',

--- a/resources/views/folders/create.blade.php
+++ b/resources/views/folders/create.blade.php
@@ -37,7 +37,8 @@
                 @csrf 
                 <div class="form-group">
                   <label for="title">フォルダ名</label>
-                  <input type="text" class="form-control" name="title" id="title" />
+                  <!-- 入力エラーでフォーム画面に戻ったとき、old関数からセッション値を取得し、入力欄の値を復元させる -->
+                  <input type="text" class="form-control" name="title" id="title" value="{{ old('title') }}" />
                 </div>
                 <div class="text-right">
                   <button type="submit" class="btn btn-primary">送信</button>

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,3 +25,8 @@ Route::get('/folders/{id}/tasks', 'TaskController@index')->name('tasks.index');
 Route::get('/folders/create', 'FolderController@showCreateForm')->name('folders.create'); // 名前付きルートを使うことでURLを一括変更できる
 // フォルダ作成処理を実行する
 Route::post('/folders/create', 'FolderController@create'); // 同じURLでHTTPメソッド違いのルートがいくつかある場合、どれか一つに名前をつければいい
+
+// タスク作成ページを表示する 
+Route::get('/folders/{id}/tasks/create', 'TaskController@showCreateForm')->name('tasks.create'); 
+// タスク作成処理を実行する 
+Route::post('/folders/{id}/tasks/create', 'TaskController@create');


### PR DESCRIPTION
タスク作成機能を実装するためルーティングでURL設計を行い、タスクコントローラーにshowCreateForm メソッドを追加し、入力フォームを表示するルートを実装する。