### PR TITLE
テンプレートファイルをレイアウトファイルにまとめる

### DIFF
--- a/resources/views/folders/create.blade.php
+++ b/resources/views/folders/create.blade.php
@@ -1,54 +1,39 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge"> <!-- IEのバージョンごとに表示崩れがしないよう、各バージョンのモードでレンダリングする -->
-  <title>ToDo App</title>
-  <link rel="stylesheet" href="/css/styles.css">
-</head>
-<body>
-  <header>
-    <nav class="my-navbar">
-      <a class="my-navbar-brand" href="/">ToDo App</a>
-    </nav>
-  </header>
-  <main>
-    <div class="container">
-      <div class="row">
-        <div class="col col-md-offset-3 col-md-6">
-          <nav class="panel panel-default">
-            <div class="panel-heading">フォルダを追加する</div>
-            <div class="panel-body">
-              <!-- ルール違反の内容が詰められた$errors変数を使ってルール違反があったかを確認する -->
-              @if($errors->any())
-                <div class="alert alert-danger">
-                  <ul>
-                    <!-- ルール違反があった場合、エラーメッセージを列挙する -->
-                    @foreach($errors->all() as $message)
-                      <li>{{ $message }}</li>
-                    @endforeach
-                  </ul>
-                </div>
-              @endif
-            　<!-- formアクションでurlを呼び出し、フォームを使ってデータを送る -->
-              <form action="{{ route('folders.create') }}" method="post"> 
-              　<!-- 他サイトからの悪意あるPOSTリクエストを受け付けないよう、自分のサイトからのPOSTリクエストだけ受け付けるため、CSRFトークンを用いる -->
-                @csrf 
-                <div class="form-group">
-                  <label for="title">フォルダ名</label>
-                  <!-- 入力エラーでフォーム画面に戻ったとき、old関数からセッション値を取得し、入力欄の値を復元させる -->
-                  <input type="text" class="form-control" name="title" id="title" value="{{ old('title') }}" />
-                </div>
-                <div class="text-right">
-                  <button type="submit" class="btn btn-primary">送信</button>
-                </div>
-              </form>
-            </div>
-          </nav>
-        </div>
+@extends('layout')
+
+@section('content')
+  <div class="container">
+    <div class="row">
+      <div class="col col-md-offset-3 col-md-6">
+        <nav class="panel panel-default">
+          <div class="panel-heading">フォルダを追加する</div>
+          <div class="panel-body">
+            <!-- ルール違反の内容が詰められた$errors変数を使ってルール違反があったかを確認する -->
+            @if($errors->any())
+              <div class="alert alert-danger">
+                <ul>
+                  <!-- ルール違反があった場合、エラーメッセージを列挙する -->
+                  @foreach($errors->all() as $message)
+                    <li>{{ $message }}</li>
+                  @endforeach
+                </ul>
+              </div>
+            @endif
+          　<!-- formアクションでurlを呼び出し、フォームを使ってデータを送る -->
+            <form action="{{ route('folders.create') }}" method="post"> 
+            　<!-- 他サイトからの悪意あるPOSTリクエストを受け付けないよう、自分のサイトからのPOSTリクエストだけ受け付けるため、CSRFトークンを用いる -->
+              @csrf 
+              <div class="form-group">
+                <label for="title">フォルダ名</label>
+                <!-- 入力エラーでフォーム画面に戻ったとき、old関数からセッション値を取得し、入力欄の値を復元させる -->
+                <input type="text" class="form-control" name="title" id="title" value="{{ old('title') }}" />
+              </div>
+              <div class="text-right">
+                <button type="submit" class="btn btn-primary">送信</button>
+              </div>
+            </form>
+          </div>
+        </nav>
       </div>
     </div>
-  </main>
-</body>
-</html>
+  </div>
+@endsection

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">  <!-- IEのバージョンごとに表示崩れがしないよう、各バージョンのモードでレンダリングする -->
+  <title>ToDo App</title>
+  <!-- section ～ endsectionに置き換わってHTMLが作成される -->
+  @yield('styles')
+  <link rel="stylesheet" href="/css/styles.css">
+</head>
+<body>
+<header>
+  <nav class="my-navbar">
+    <a class="my-navbar-brand" href="/">ToDo App</a>
+  </nav>
+</header>
+<main>
+　<!-- section ～ endsectionに置き換わってHTMLが作成される -->
+  @yield('content')
+</main>
+<!-- section ～ endsectionに置き換わってHTMLが作成される -->
+@yield('scripts')
+</body>
+</html>

--- a/resources/views/tasks/create.blade.php
+++ b/resources/views/tasks/create.blade.php
@@ -1,24 +1,17 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge"> <!-- IEのバージョンごとに表示崩れがしないよう、各バージョンのモードでレンダリングする -->
-  <title>ToDo App</title>
+<!-- resources/views/layout.blade.phpをレイアウトファイルとして使用することを宣言 -->
+@extends('layout')
+
+<!-- レイアウトファイルのyieldに対応している -->
+@section('styles')
   <!-- スタイルシートはhead内で読み込む -->
   <!-- JavaScriptのflatpickrライブラリを読み込む -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
   <!-- flatpickrライブラリの色をブルーテーマにカスタマイズするためのファイルを読み込む -->
   <link rel="stylesheet" href="https://npmcdn.com/flatpickr/dist/themes/material_blue.css">
-  <link rel="stylesheet" href="/css/styles.css">
-</head>
-<body>
-<header>
-  <nav class="my-navbar">
-    <a class="my-navbar-brand" href="/">ToDo App</a>
-  </nav>
-</header>
-<main>
+@endsection
+
+<!-- レイアウトファイルのyieldに対応している -->
+@section('content') 
   <div class="container">
     <div class="row">
       <div class="col col-md-offset-3 col-md-6">
@@ -58,8 +51,10 @@
       </div>
     </div>
   </div>
-</main>
+@endsection
 
+<!-- レイアウトファイルのyieldに対応している -->
+@section('scripts')
 <!-- スクリプトはbodyの一番最後で読み込む -->
 <!-- flatpickrスクリプトを読み込む -->
 <script src="https://npmcdn.com/flatpickr/dist/flatpickr.min.js"></script>
@@ -75,5 +70,4 @@
     minDate: new Date()
   });
 </script>
-</body>
-</html>
+@endsection

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -1,19 +1,6 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>ToDo App</title>
-  <link rel="stylesheet" href="/css/styles.css">
-</head>
-<body>
-<header>
-  <nav class="my-navbar">
-    <a class="my-navbar-brand" href="/">ToDo App</a>
-  </nav>
-</header>
-<main>
+@extends('layout')
+
+@section('content')
   <div class="container">
     <div class="row">
       <div class="col col-md-4">
@@ -80,6 +67,4 @@
       </div>
     </div>
   </div>
-</main>
-</body>
-</html>
+@endsection


### PR DESCRIPTION
今まで作成した３つのテンプレートファイル、タスク一覧ページ、タスク作成画面、フォルダ作成画面の中でいくつか重複した記述があったので、レイアウトファイルを作成して重複した箇所を一つにまとめる。resources/views/layout.blade.phpファイルを作成し、３つのテンプレートファイルのページごとに変わらない箇所だけを記述する。ページごとに変化する部分は@yieldで穴埋めにして、テンプレートファイルごとに記述した@section～@endsectionの引数で受け取る。
![スクリーンショット (25)](https://user-images.githubusercontent.com/61861236/79190346-0b9c3180-7e5f-11ea-9c5c-1d11dd9c9665.png)
![スクリーンショット (26)](https://user-images.githubusercontent.com/61861236/79190348-0d65f500-7e5f-11ea-8d17-d660fb9034eb.png)
![スクリーンショット (27)](https://user-images.githubusercontent.com/61861236/79190353-0f2fb880-7e5f-11ea-9b36-5d07436ad7e4.png)
ブラウザで確認したところ、無事表示できました。