### PR TITLE
タスクを追加するためのコントローラーを実装する

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Folder;
 use App\Task; //Taskモデルを読み込む
 use Illuminate\Http\Request;
+use App\Http\Requests\CreateTask; // CreateTaskコントローラーをインポートする
 
 class TaskController extends Controller
 {
@@ -36,5 +37,29 @@ class TaskController extends Controller
         return view('tasks/create', [
              'folder_id' => $id
         ]); 
+    }
+
+    // タスクを保存するcreateメソッドを追加する
+    public function create(int $id, CreateTask $request)
+    {
+        // フォルダidを取得し、currrent_folderに代入する
+        $current_folder = Folder::find($id);
+
+        // タスクモデルのインスタンスを作成
+        $task = new Task();
+        // タイトルと期限日の入力値を代入する
+        $task->title = $request->title;
+        $task->due_date = $request->due_date;
+
+        // current_folderに紐づくタスクを保存する
+        $current_folder->tasks()->save($task);
+
+        /** 
+         * タスクを作成するルートに画面の出力は必要ないので、フォルダに紐づくタスクをタスク一覧画面に
+         * redirectメソッドを呼び出し偏移させる
+         */
+        return redirect()->route('tasks.index', [
+            'id' => $current_folder->id,
+        ]);
     }
 }

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -30,7 +30,8 @@
           <div class="panel-heading">タスク</div>
           <div class="panel-body">
             <div class="text-right">
-              <a href="#" class="btn btn-default btn-block">
+              <!-- フォルダに紐づいたタスクのデータをコントローラーから受け取り、表示する -->
+              <a href="{{ route('tasks.create', ['id' => $current_folder_id]) }}" class="btn btn-default btn-block">
                 タスクを追加する
               </a>
             </div>


### PR DESCRIPTION
フォルダに紐づいたタスクを追加するためのコントローラー、createメソッドを実装し、テンプレートtasks/index.blade.phpでデータを受け取り、ブラウザに表示する。
新しいタスク、「サンプルタスク４」と「期限日」を確認のため追加しました。
![スクリーンショット (28)](https://user-images.githubusercontent.com/61861236/79709747-f8c1ab00-82fd-11ea-8163-ab524b2bebe3.png)
![スクリーンショット (31)](https://user-images.githubusercontent.com/61861236/79709752-fb240500-82fd-11ea-9053-f18d7611eb9c.png)
![スクリーンショット (29)](https://user-images.githubusercontent.com/61861236/79709754-fd865f00-82fd-11ea-9821-55a5c6bf83d3.png)
ブラウザに表示したところ、無事確認できました。