### PR TITLE
期限日のバリデーションをテストする

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Folder;
 use App\Task; //Taskモデルを読み込む
 use Illuminate\Http\Request;
+use App\Http\Requests\CreateTask; // CreateTaskコントローラーをインポートする
 
 class TaskController extends Controller
 {
@@ -36,5 +37,29 @@ class TaskController extends Controller
         return view('tasks/create', [
              'folder_id' => $id
         ]); 
+    }
+
+    // タスクを保存するcreateメソッドを追加する
+    public function create(int $id, CreateTask $request)
+    {
+        // フォルダidを取得し、currrent_folderに代入する
+        $current_folder = Folder::find($id);
+
+        // タスクモデルのインスタンスを作成
+        $task = new Task();
+        // タイトルと期限日の入力値を代入する
+        $task->title = $request->title;
+        $task->due_date = $request->due_date;
+
+        // current_folderに紐づくタスクを保存する
+        $current_folder->tasks()->save($task);
+
+        /** 
+         * タスクを作成するルートに画面の出力は必要ないので、フォルダに紐づくタスクをタスク一覧画面に
+         * redirectメソッドを呼び出し偏移させる
+         */
+        return redirect()->route('tasks.index', [
+            'id' => $current_folder->id,
+        ]);
     }
 }

--- a/config/database.php
+++ b/config/database.php
@@ -43,6 +43,13 @@ return [
             'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
         ],
 
+        'sqlite_testing' => [
+            'driver' => 'sqlite',
+            // データの保存先がメモリ上になる
+            'database' => ':memory:',
+            'prefix' => '',
+        ],
+
         'mysql' => [
             'driver' => 'mysql',
             'url' => env('DATABASE_URL'),

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,6 +18,7 @@
     </filter>
     <php>
         <server name="APP_ENV" value="testing"/>
+        <server name="DB_CONNECTION" value="sqlite_testing"/> <!--　DBをテスト用に切り替える -->
         <server name="BCRYPT_ROUNDS" value="4"/>
         <server name="CACHE_DRIVER" value="array"/>
         <server name="DB_CONNECTION" value="sqlite"/>

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -30,7 +30,8 @@
           <div class="panel-heading">タスク</div>
           <div class="panel-body">
             <div class="text-right">
-              <a href="#" class="btn btn-default btn-block">
+              <!-- フォルダに紐づいたタスクのデータをコントローラーから受け取り、表示する -->
+              <a href="{{ route('tasks.create', ['id' => $current_folder_id]) }}" class="btn btn-default btn-block">
                 タスクを追加する
               </a>
             </div>

--- a/tests/Feature/TaskTest.php
+++ b/tests/Feature/TaskTest.php
@@ -56,4 +56,63 @@ class TaskTest extends TestCase
             'due_date' => '期限日 には今日以降の日付を入力してください。',
         ]);
     }
+
+    /**
+     * 期限日が日付だった場合はタスク一覧ページへリダイレクトする
+     * @test
+     */
+    public function due_date()
+    {
+        $response = $this->post('/folders/1/tasks/create', [
+            'title' => 'Sample task',
+            'due_date' => '2020/04/30', // 正常なデータ（数値）
+        ]);
+
+        $response->assertRedirect('/folders/1/tasks');
+    }
+
+
+     /**
+     * 期限日が今日以降の場合はタスク一覧ページへリダイレクトする
+     * @test
+     */
+    public function due_date_today()
+    {
+        $response = $this->post('/folders/1/tasks/create', [
+            'title' => 'Sample task',
+            'due_date' => Carbon::today()->format('Y/m/d'), // 正常なデータ（今日の日付）
+        ]);
+
+        $response->assertRedirect('/folders/1/tasks');
+    }
+
+    /**
+     * 期限日がうるう年でもデータが正常に保存されるかをチェック
+     * @test
+     */
+    public function due_date_leap()
+    {
+        $response = $this->post('/folders/1/tasks/create', [
+            'title' => 'Sample task',
+            'due_date' => '2024/02/29', // 正常なうるう年のデータ（数値）
+        ]);
+
+        $response->assertRedirect('/folders/1/tasks');
+    }
+
+      /**
+     *  期限日が存在しないうるう年の日付に対してエラーを返す
+     * @test
+     */
+    public function due_date_not_leep()
+    {
+        $response = $this->post('/folders/1/tasks/create', [
+            'title' => 'Sample task',
+            'due_date' => '2025/02/29', // 存在しないデータ（数値）
+        ]);
+
+        $response->assertSessionHasErrors([
+            'due_date' => '期限日 には日付を入力してください。',
+        ]);
+    }
 }

--- a/tests/Feature/TaskTest.php
+++ b/tests/Feature/TaskTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Requests\CreateTask;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class TaskTest extends TestCase
+{
+    // テストケースごとにデータベースをリフレッシュしてマイグレーションを再実行する
+    use RefreshDatabase;
+
+    /**
+     * 各テストメソッドの実行前に呼ばれる
+     * voidで戻り値の型を返すとエラーになる
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // テストケース実行前にフォルダデータを作成する
+        $this->seed('FoldersTableSeeder');
+    }
+
+    /**
+     * 期限日が日付ではない場合はバリデーションエラーを返す
+     * @test
+     */
+    public function due_date_should_be_date()
+    {
+        $response = $this->post('/folders/1/tasks/create', [
+            'title' => 'Sample task',
+            'due_date' => 123, // 不正なデータ（数値）
+        ]);
+
+        $response->assertSessionHasErrors([
+            'due_date' => '期限日 には日付を入力してください。',
+        ]);
+    }
+
+    /**
+     * 期限日が過去日付の場合はバリデーションエラーを返す
+     * @test
+     */
+    public function due_date_should_not_be_past()
+    {
+        $response = $this->post('/folders/1/tasks/create', [
+            'title' => 'Sample task',
+            'due_date' => Carbon::yesterday()->format('Y/m/d'), // 不正なデータ（昨日の日付）
+        ]);
+
+        $response->assertSessionHasErrors([
+            'due_date' => '期限日 には今日以降の日付を入力してください。',
+        ]);
+    }
+}


### PR DESCRIPTION
期限日の入力欄をjavascriptで今日以前の入力を制御しているため、不正なデータをきちんと弾いているかを確認するためテストコードを実行する。開発用のデータベースとは別に、メモリ上のデータベースを設定し、LaravelがサポートしているテスティングライブラリPHPUnitを使用する。
>php artisan make:test TaskTest

でテストコードのひな型を作成し、TaskTest.phpにテストコードを記述する。
setUpメソッドでフォルダデータが入ったシーダーを実行し、各テストメソッドを実装する。
@testアノテーションをコメントにつけることでテストメソッドとして認識され、assertSessionHasErrorsメソッドでエラーメッセージがあるかどうか確かめている。

> ./vendor/bin/phpunit ./tests/Feature/TaskTest.php --testdox

でテストを実行する。
![スクリーンショット (33)](https://user-images.githubusercontent.com/61861236/79714783-cf5c4b80-830c-11ea-9cf1-fdb2f3c6b3de.png)
無事、確認できました。