### PR TITLE
テンプレートファイルをパーシャル化する

### DIFF
--- a/resources/views/share/flatpickr/scripts.blade.php
+++ b/resources/views/share/flatpickr/scripts.blade.php
@@ -1,0 +1,14 @@
+<!-- flatpickrスクリプトを読み込む -->
+<script src="https://npmcdn.com/flatpickr/dist/flatpickr.min.js"></script>
+<!-- 日本語化するためのスクリプト追加する -->
+<script src="https://npmcdn.com/flatpickr/dist/l10n/ja.js"></script>
+
+<!-- getElementByIdは任意のHTMLタグで指定した引数にマッチするドキュメント要素を取得するメソッド -->
+<!-- minDateオプションで本日の日付より若い日付を入力できないようにする -->
+<script>
+  flatpickr(document.getElementById('due_date'), {
+    locale: 'ja',
+    dateFormat: "Y/m/d",
+    minDate: new Date()
+  });
+</script>

--- a/resources/views/share/flatpickr/styles.blade.php
+++ b/resources/views/share/flatpickr/styles.blade.php
@@ -1,0 +1,4 @@
+<!-- JavaScriptのflatpickrライブラリを読み込む -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+<!-- flatpickrライブラリの色をブルーテーマにカスタマイズするためのファイルを読み込む -->
+<link rel="stylesheet" href="https://npmcdn.com/flatpickr/dist/themes/material_blue.css">

--- a/resources/views/tasks/create.blade.php
+++ b/resources/views/tasks/create.blade.php
@@ -1,13 +1,9 @@
 <!-- resources/views/layout.blade.phpをレイアウトファイルとして使用することを宣言 -->
 @extends('layout')
 
-<!-- レイアウトファイルのyieldに対応している -->
+<!-- flatpickr/sytylesファイルのyieldに対応している -->
 @section('styles')
-  <!-- スタイルシートはhead内で読み込む -->
-  <!-- JavaScriptのflatpickrライブラリを読み込む -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
-  <!-- flatpickrライブラリの色をブルーテーマにカスタマイズするためのファイルを読み込む -->
-  <link rel="stylesheet" href="https://npmcdn.com/flatpickr/dist/themes/material_blue.css">
+  @include('share.flatpickr.styles')
 @endsection
 
 <!-- レイアウトファイルのyieldに対応している -->
@@ -53,21 +49,7 @@
   </div>
 @endsection
 
-<!-- レイアウトファイルのyieldに対応している -->
+<!-- flatpickr/scriptsファイルのyieldに対応している -->
 @section('scripts')
-<!-- スクリプトはbodyの一番最後で読み込む -->
-<!-- flatpickrスクリプトを読み込む -->
-<script src="https://npmcdn.com/flatpickr/dist/flatpickr.min.js"></script>
-<!-- 日本語化するためのスクリプト追加する -->
-<script src="https://npmcdn.com/flatpickr/dist/l10n/ja.js"></script>
-
-<!-- getElementByIdは任意のHTMLタグで指定した引数にマッチするドキュメント要素を取得するメソッド -->
-<!-- minDateオプションで本日の日付より若い日付を入力できないようにする -->
-<script>
-  flatpickr(document.getElementById('due_date'), {
-    locale: 'ja',
-    dateFormat: "Y/m/d",
-    minDate: new Date()
-  });
-</script>
+  @include('share.flatpickr.scripts')
 @endsection

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -1,8 +1,8 @@
 @extends('layout')
 
+<!-- flatpickr/sytylesファイルのyieldに対応している -->
 @section('styles')
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
-  <link rel="stylesheet" href="https://npmcdn.com/flatpickr/dist/themes/material_blue.css">
+  @include('share.flatpickr.styles')
 @endsection
 
 @section('content')
@@ -69,21 +69,7 @@
   </div>
 @endsection
 
-<!-- レイアウトファイルのyieldに対応している -->
+<!-- flatpickr/scriptsファイルのyieldに対応している -->
 @section('scripts')
-  <!-- スクリプトはbodyの一番最後で読み込む -->
-  <!-- flatpickrスクリプトを読み込む -->
-  <script src="https://npmcdn.com/flatpickr/dist/flatpickr.min.js"></script>
-  <!-- 日本語化するためのスクリプト追加する -->
-  <script src="https://npmcdn.com/flatpickr/dist/l10n/ja.js"></script>
-
-  <!-- getElementByIdは任意のHTMLタグで指定した引数にマッチするドキュメント要素を取得するメソッド -->
-  <!-- minDateオプションで本日の日付より若い日付を入力できないようにする -->
-  <script>
-    flatpickr(document.getElementById('due_date'), {
-      locale: 'ja',
-      dateFormat: "Y/m/d",
-      minDate: new Date()
-    });
-  </script>
+  @include('share.flatpickr.scripts')
 @endsection


### PR DESCRIPTION
タスク作成画面、タスク編集画面の共通部分をパーシャル化し、別ファイルからインクルードする。
```
$ mkdir -p ./resources/views/share/flatpickr
$ touch ./resources/views/share/flatpickr/styles.blade.php
$ touch ./resources/views/share/flatpickr/scripts.blade.php
```
で共通部分を入れるファイルを作成し、タスク作成画面、タスク編集画面の共通となる部分、スクリプトとスタイルをテンプレートファイルにインクルードする。
![スクリーンショット (38)](https://user-images.githubusercontent.com/61861236/80447248-dfe77400-8953-11ea-907c-cf020b7cd3af.png)
![スクリーンショット (39)](https://user-images.githubusercontent.com/61861236/80447256-e249ce00-8953-11ea-9d01-8c677a8a4069.png)
ブラウザで確認したところ、無事表示されました。