### PR TITLE
タスク編集機能のコントローラーの実装

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -6,6 +6,7 @@ use App\Folder;
 use App\Task; //Taskモデルを読み込む
 use Illuminate\Http\Request;
 use App\Http\Requests\CreateTask; // CreateTaskコントローラーをインポートする
+use App\Http\Requests\EditTask; // EditTaskコントローラーをインポートする
 
 class TaskController extends Controller
 {
@@ -72,6 +73,28 @@ class TaskController extends Controller
         // タスク編集テンプレートにタスクデータを渡す
         return view('tasks/edit', [
             'task' => $task,
+        ]);
+    }
+
+    public function edit(int $id, int $task_id, EditTask $request)
+    {
+        // リクエストを受けたIDからタスクデータを取得する
+        $task = Task::find($task_id);
+
+        // タイトルと期限日、状態の入力値を代入する
+        $task->title = $request->title;
+        $task->status = $request->status;
+        $task->due_date = $request->due_date;
+        // タスクを保存する
+        $task->save();
+
+    
+        /** 
+         * タスクを作成するルートに画面の出力は必要ないので、フォルダに紐づくタスクをタスク一覧画面に
+         * redirectメソッドを呼び出し偏移させる
+         */
+        return redirect()->route('tasks.index', [
+            'id' => $task->folder_id,
         ]);
     }
 }

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -59,7 +59,12 @@
                   </td>
                   <!-- 日付変更のメソッドを参照 -->
                   <td>{{ $task->formatted_due_date }}</td>
-                  <td><a href="#">編集</a></td>
+                  <td>
+                    <!-- タスク一覧画面への編集リンク -->
+                    <a href="{{ route('tasks.edit', ['id' => $task->folder_id, 'task_id' => $task->id]) }}">
+                        編集
+                    </a>
+                  </td>
                 </tr>
               @endforeach
             </tbody>


### PR DESCRIPTION
タスク編集のデータを渡すコントローラーを実装し、一覧画面に反映させ、リダイレクトする。
また、タスク一覧画面から編集画面に飛べるように、リンクを追加する。
![スクリーンショット (44)](https://user-images.githubusercontent.com/61861236/80457968-18df1300-896b-11ea-986d-19aa555d6d5f.png)
![スクリーンショット (45)](https://user-images.githubusercontent.com/61861236/80457975-1aa8d680-896b-11ea-9317-edca7c16df5b.png)
![スクリーンショット (46)](https://user-images.githubusercontent.com/61861236/80457981-1b416d00-896b-11ea-9d73-90820d57968b.png)
![スクリーンショット (47)](https://user-images.githubusercontent.com/61861236/80457992-1e3c5d80-896b-11ea-91e7-22069e1f2361.png)
ブラウザで確認したところ、無事表示されました。