### PR TITLE
状態のバリデーションをテストする

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -6,6 +6,7 @@ use App\Folder;
 use App\Task; //Taskモデルを読み込む
 use Illuminate\Http\Request;
 use App\Http\Requests\CreateTask; // CreateTaskコントローラーをインポートする
+use App\Http\Requests\EditTask; // EditTaskコントローラーをインポートする
 
 class TaskController extends Controller
 {
@@ -72,6 +73,28 @@ class TaskController extends Controller
         // タスク編集テンプレートにタスクデータを渡す
         return view('tasks/edit', [
             'task' => $task,
+        ]);
+    }
+
+    public function edit(int $id, int $task_id, EditTask $request)
+    {
+        // リクエストを受けたIDからタスクデータを取得する
+        $task = Task::find($task_id);
+
+        // タイトルと期限日、状態の入力値を代入する
+        $task->title = $request->title;
+        $task->status = $request->status;
+        $task->due_date = $request->due_date;
+        // タスクを保存する
+        $task->save();
+
+    
+        /** 
+         * タスクを作成するルートに画面の出力は必要ないので、フォルダに紐づくタスクをタスク一覧画面に
+         * redirectメソッドを呼び出し偏移させる
+         */
+        return redirect()->route('tasks.index', [
+            'id' => $task->folder_id,
         ]);
     }
 }

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -59,7 +59,12 @@
                   </td>
                   <!-- 日付変更のメソッドを参照 -->
                   <td>{{ $task->formatted_due_date }}</td>
-                  <td><a href="#">編集</a></td>
+                  <td>
+                    <!-- タスク一覧画面への編集リンク -->
+                    <a href="{{ route('tasks.edit', ['id' => $task->folder_id, 'task_id' => $task->id]) }}">
+                        編集
+                    </a>
+                  </td>
                 </tr>
               @endforeach
             </tbody>

--- a/tests/Feature/TaskTest.php
+++ b/tests/Feature/TaskTest.php
@@ -115,4 +115,39 @@ class TaskTest extends TestCase
             'due_date' => '期限日 には日付を入力してください。',
         ]);
     }
+
+    /**
+     * 状態が定義された値の場合はタスク一覧ページへリダイレクトする
+     * @test
+     */
+    public function status_should_be_within_defined_numbers()
+    {
+        $this->seed('TasksTableSeeder');
+
+        $response = $this->post('/folders/1/tasks/1/edit', [
+            'title' => 'Sample task',
+            'due_date' => Carbon::today()->format('Y/m/d'),
+            'status' => 999, // 不正なデータ（数値）
+        ]);
+
+        $response->assertSessionHasErrors([
+            'status' => '状態 には 未着手、着手中、完了 のいずれかを指定してください。',
+        ]);
+    }
+
+    /**
+     * 状態が定義された値の場合はエラーを返す
+     * @test
+     */
+    public function status()
+    {
+        $response = $this->post('/folders/1/tasks/create', [
+            'title' => 'Sample task',
+            'due_date' => Carbon::today()->format('Y/m/d'),
+            'status' => 1,
+        ]);
+
+        $response->assertRedirect('/folders/1/tasks');
+    }
+
 }


### PR DESCRIPTION
状態に不正な数値が入った場合のエラーの挙動がブラウザからは確認できないため、TaskTest.phpにてテストコードを記述し、バリデーションのチェックをしました。
不正な値が入った場合、正常な値が入った場合の挙動のテストを行い、
![スクリーンショット (48)](https://user-images.githubusercontent.com/61861236/80460206-7759c080-896e-11ea-80ca-8f748745e61e.png)
コマンドラインで確認したところ、無事テスト成功いたしました。