### PR TITLE
会員登録機能を実装する

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -26,7 +26,7 @@ class LoginController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = RouteServiceProvider::HOME;
+    protected $redirectTo = "/";
 
     /**
      * Create a new controller instance.

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -29,7 +29,7 @@ class RegisterController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = RouteServiceProvider::HOME;
+    protected $redirectTo = '/'; // 登録に成功した後のリダイレクト先を設定する
 
     /**
      * Create a new controller instance.

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -29,7 +29,7 @@ class RegisterController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = '/'; // 登録に成功した後のリダイレクト先を設定する
+    protected $redirectTo = '/completion'; // 登録に成功した後のリダイレクト先を設定する
 
     /**
      * Create a new controller instance.

--- a/app/Http/Controllers/CompletionController.php
+++ b/app/Http/Controllers/CompletionController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class CompletionController extends Controller
+{
+    // 登録完了ページを表示するためのコントローラーを設定する
+    public function index()
+    {
+        return view('completion');
+    }
+}

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -18,8 +18,9 @@ class RedirectIfAuthenticated
      */
     public function handle($request, Closure $next, $guard = null)
     {
+        // 認証済み（ログイン済み）の状態でログインページにアクセスすると、ログイン後のトップページにリダイレクトする
         if (Auth::guard($guard)->check()) {
-            return redirect(RouteServiceProvider::HOME);
+            return redirect('/');
         }
 
         return $next($request);

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,77 +1,48 @@
-@extends('layouts.app')
+@extends('layout')
 
 @section('content')
-<div class="container">
-    <div class="row justify-content-center">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header">{{ __('Register') }}</div>
-
-                <div class="card-body">
-                    <form method="POST" action="{{ route('register') }}">
-                        @csrf
-
-                        <div class="form-group row">
-                            <label for="name" class="col-md-4 col-form-label text-md-right">{{ __('Name') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="name" type="text" class="form-control @error('name') is-invalid @enderror" name="name" value="{{ old('name') }}" required autocomplete="name" autofocus>
-
-                                @error('name')
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </span>
-                                @enderror
-                            </div>
-                        </div>
-
-                        <div class="form-group row">
-                            <label for="email" class="col-md-4 col-form-label text-md-right">{{ __('E-Mail Address') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="email" type="email" class="form-control @error('email') is-invalid @enderror" name="email" value="{{ old('email') }}" required autocomplete="email">
-
-                                @error('email')
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </span>
-                                @enderror
-                            </div>
-                        </div>
-
-                        <div class="form-group row">
-                            <label for="password" class="col-md-4 col-form-label text-md-right">{{ __('Password') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="password" type="password" class="form-control @error('password') is-invalid @enderror" name="password" required autocomplete="new-password">
-
-                                @error('password')
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </span>
-                                @enderror
-                            </div>
-                        </div>
-
-                        <div class="form-group row">
-                            <label for="password-confirm" class="col-md-4 col-form-label text-md-right">{{ __('Confirm Password') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="password-confirm" type="password" class="form-control" name="password_confirmation" required autocomplete="new-password">
-                            </div>
-                        </div>
-
-                        <div class="form-group row mb-0">
-                            <div class="col-md-6 offset-md-4">
-                                <button type="submit" class="btn btn-primary">
-                                    {{ __('Register') }}
-                                </button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-            </div>
-        </div>
+  <div class="container">
+    <div class="row">
+      <div class="col col-md-offset-3 col-md-6">
+        <nav class="panel panel-default">
+          <div class="panel-heading">会員登録</div>
+          <div class="panel-body">
+            <!-- ルール違反の内容が詰められた$errors変数を使ってルール違反があったかを確認する -->
+            @if($errors->any())
+              <div class="alert alert-danger">
+                <!-- ルール違反があった場合、エラーメッセージを列挙する -->
+                @foreach($errors->all() as $message)
+                  <p>{{ $message }}</p>
+                @endforeach
+              </div>
+            @endif
+            <!-- Auth::routesで定義されたルートを利用し、認証機能を定義する -->
+            <form action="{{ route('register') }}" method="POST">
+              @csrf
+              <div class="form-group">
+                <label for="email">メールアドレス</label>
+                <input type="text" class="form-control" id="email" name="email" value="{{ old('email') }}" />
+              </div>
+              <div class="form-group">
+                <label for="name">ユーザー名</label>
+                <input type="text" class="form-control" id="name" name="name" value="{{ old('name') }}" />
+              </div>
+              <div class="form-group">
+                <label for="password">パスワード</label>
+                <input type="password" class="form-control" id="password" name="password">
+              </div>
+              <div class="form-group">
+              　<!--  Laravelに用意されたconfirmedルールを設定し、項目名（password）＋_confirmationが一致するかどうかを検証する -->
+                <label for="password-confirm">パスワード（確認）</label>
+                <input type="password" class="form-control" id="password-confirm" name="password_confirmation">
+              </div>
+              <div class="text-right">
+                <button type="submit" class="btn btn-primary">送信</button>
+              </div>
+            </form>
+          </div>
+        </nav>
+      </div>
     </div>
-</div>
+  </div>
 @endsection

--- a/resources/views/completion.blade.php
+++ b/resources/views/completion.blade.php
@@ -1,0 +1,23 @@
+@extends('layout')
+
+@section('content')
+  <div class="container">
+    <div class="row">
+      <div class="col col-md-offset-3 col-md-6">
+        <nav class="panel panel-default">
+          <div class="panel-heading">
+            登録完了しました
+          </div>
+          <div class="panel-body">
+            <div class="text-center">
+              <!-- ログインページへのリンクを表示する -->
+              <a href="{{ route('login') }}" class="btn btn-primary">
+                ログインページへ
+              </a>
+            </div>
+          </div>
+        </nav>
+      </div>
+    </div>
+  </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,11 +13,8 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::get('/', function () {
-    return view('welcome');
-});
-
-Auth::routes();
+// トップページを表示する
+Route::get('/', 'HomeController@index')->name('home');
 
 Route::get('/folders/{id}/tasks', 'TaskController@index')->name('tasks.index');
 
@@ -36,8 +33,8 @@ Route::get('/folders/{id}/tasks/{task_id}/edit', 'TaskController@showEditForm')-
 // タスク編集処理を実行する 
 Route::post('/folders/{id}/tasks/{task_id}/edit', 'TaskController@edit');
 
-// トップページを表示する
-Route::get('/', 'HomeController@index')->name('home');
+// 登録完了ページを表示する
+Route::get('/completion', 'CompletionController@index')->name('completion');
 
 // 会員登録・ログイン・ログアウト・パスワード再設定の各機能で必要なルーティング設定をすべて定義する
 Auth::routes();

--- a/routes/web.php
+++ b/routes/web.php
@@ -38,3 +38,6 @@ Route::post('/folders/{id}/tasks/{task_id}/edit', 'TaskController@edit');
 
 // トップページを表示する
 Route::get('/', 'HomeController@index')->name('home');
+
+// 会員登録・ログイン・ログアウト・パスワード再設定の各機能で必要なルーティング設定をすべて定義する
+Auth::routes();


### PR DESCRIPTION
Laravelには認証機能が最初から搭載されていて、コントローラーはすでに用意され、ルーティングも認証用の設定を吐き出すメソッドが用意されているので、基本的にはテンプレートを作成することで認証機能の実装が可能である。
ルーティングに
>Auth::routes();

を追加し、このメソッドが会員登録・ログイン・ログアウト・パスワード再設定の各機能で必要なルーティング設定をすべて定義している。
会員登録ページを表示するテンプレートを作成し、コントローラーに会員登録が成功したあと、トップページへ偏移するプロパティの値を追加し、リダイレクトさせる。
/registerにアクセスし、ブラウザを確認したところ、無事表示されました。

![スクリーンショット (60)](https://user-images.githubusercontent.com/61861236/81647566-2f579500-9468-11ea-958a-449e36fda99a.png)

また、会員登録が成功し、トップページへ画面が偏移することも無事確認できました。

![スクリーンショット (61)](https://user-images.githubusercontent.com/61861236/81647570-3088c200-9468-11ea-88cf-618f572e181d.png)

コマンドラインからデータベースを確認したところ、「テスト太郎」は登録できていたのですが、email_verified_atやremember_tokenがNULLになっていたので、理由がわかり次第報告いたします。
![スクリーンショット (62)](https://user-images.githubusercontent.com/61861236/81647961-d9372180-9468-11ea-98d4-8c4ec8533553.png)

