### PR TITLE
ページの表示に認証を求める

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -11,8 +11,25 @@
 </head>
 <body>
 <header>
-  <nav class="my-navbar">
+<nav class="my-navbar">
     <a class="my-navbar-brand" href="/">ToDo App</a>
+    <div class="my-navbar-control">
+      <!-- ログインしていればtrueを返し、ログインしてなければfalseを返す -->
+      <!-- Auth::guestの場合はユーザーがログインしていない場合にtrueを返す -->
+      @if(Auth::check())
+        <!-- Auth::userでログイン中のユーザーを取得する -->
+        <span class="my-navbar-item">ようこそ, {{ Auth::user()->name }}さん</span>
+        ｜
+        <a href="#" id="logout" class="my-navbar-item">ログアウト</a>
+        <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">
+          @csrf
+        </form>
+      @else
+        <a class="my-navbar-item" href="{{ route('login') }}">ログイン</a>
+        ｜
+        <a class="my-navbar-item" href="{{ route('register') }}">会員登録</a>
+      @endif
+    </div>
   </nav>
 </header>
 <main>
@@ -20,6 +37,17 @@
   @yield('content')
 </main>
 <!-- section ～ endsectionに置き換わってHTMLが作成される -->
+
+  <!-- ログアウトリンクのクリックイベントで、リンクの下に置いたフォームを送信する -->
+  @if(Auth::check())
+    <script>
+      document.getElementById('logout').addEventListener('click', function(event) {
+        event.preventDefault();
+        document.getElementById('logout-form').submit();
+      });
+    </script>
+  @endif
+
 @yield('scripts')
 </body>
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,28 +13,34 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-// トップページを表示する
-Route::get('/', 'HomeController@index')->name('home');
+// ページの認証をルートごとの処理に移る前にプログラムを実行するため、ミドルウェアを用いる
+// 認証状態の確認を様々なルートに共通して行うため、ミドルウェアが適している
+Route::group(['middleware' => 'auth'], function() {
 
-Route::get('/folders/{id}/tasks', 'TaskController@index')->name('tasks.index');
+  // トップページを表示する
+  Route::get('/', 'HomeController@index')->name('home');
 
-// フォルダ作成ページを表示する
-Route::get('/folders/create', 'FolderController@showCreateForm')->name('folders.create'); // 名前付きルートを使うことでURLを一括変更できる
-// フォルダ作成処理を実行する
-Route::post('/folders/create', 'FolderController@create'); // 同じURLでHTTPメソッド違いのルートがいくつかある場合、どれか一つに名前をつければいい
+  Route::get('/folders/{id}/tasks', 'TaskController@index')->name('tasks.index');
 
-// タスク作成ページを表示する 
-Route::get('/folders/{id}/tasks/create', 'TaskController@showCreateForm')->name('tasks.create'); 
-// タスク作成処理を実行する 
-Route::post('/folders/{id}/tasks/create', 'TaskController@create');
+  // フォルダ作成ページを表示する
+  Route::get('/folders/create', 'FolderController@showCreateForm')->name('folders.create'); // 名前付きルートを使うことでURLを一括変更できる
+  // フォルダ作成処理を実行する
+  Route::post('/folders/create', 'FolderController@create'); // 同じURLでHTTPメソッド違いのルートがいくつかある場合、どれか一つに名前をつければいい
 
-// タスク編集ページを表示する 
-Route::get('/folders/{id}/tasks/{task_id}/edit', 'TaskController@showEditForm')->name('tasks.edit');
-// タスク編集処理を実行する 
-Route::post('/folders/{id}/tasks/{task_id}/edit', 'TaskController@edit');
+  // タスク作成ページを表示する 
+  Route::get('/folders/{id}/tasks/create', 'TaskController@showCreateForm')->name('tasks.create'); 
+  // タスク作成処理を実行する 
+  Route::post('/folders/{id}/tasks/create', 'TaskController@create');
 
-// 登録完了ページを表示する
-Route::get('/completion', 'CompletionController@index')->name('completion');
+  // タスク編集ページを表示する 
+  Route::get('/folders/{id}/tasks/{task_id}/edit', 'TaskController@showEditForm')->name('tasks.edit');
+  // タスク編集処理を実行する 
+  Route::post('/folders/{id}/tasks/{task_id}/edit', 'TaskController@edit');
+
+  // 登録完了ページを表示する
+  Route::get('/completion', 'CompletionController@index')->name('completion');
+
+});
 
 // 会員登録・ログイン・ログアウト・パスワード再設定の各機能で必要なルーティング設定をすべて定義する
 Auth::routes();


### PR DESCRIPTION
ログインしていないユーザーにはページを表示させないように、ミドルウェアを適用し、ルーティング全体に一括で認証機能を追加する。
ページの認証をルートごとの処理に移る前にプログラムを実行し、認証状態の確認を様々なルートに共通して行うため、ミドルウェアが適している。

ログアウトをクリックするとログインページに飛ぶこと、さらにログアウトの状態ではトップページやその他のページに遷移できないこと、どちらもブラウザで確認できました。

![スクリーンショット (87)](https://user-images.githubusercontent.com/61861236/82407268-b4affa80-9aa3-11ea-9c3a-d70816b9ecc9.png)
![スクリーンショット (88)](https://user-images.githubusercontent.com/61861236/82407260-b2e63700-9aa3-11ea-856a-eb44358df8dd.png)

