### PR TITLE
ユーザーに紐づいたフォルダを表示する

### DIFF
--- a/app/Http/Controllers/FolderController.php
+++ b/app/Http/Controllers/FolderController.php
@@ -7,6 +7,8 @@ use App\Folder;
 use Illuminate\Http\Request;
 // CreateFolderクラスのインポート
 use App\Http\Requests\CreateFolder;
+// Authクラスをインポートする
+use Illuminate\Support\Facades\Auth;
 
 class FolderController extends Controller
 {
@@ -25,13 +27,16 @@ class FolderController extends Controller
     {
         // フォルダモデルのインスタンスを作成
         $folder = new Folder();
+
         /** 
          * タイトルに入力値を代入する
          * リクエストクラスのインスタンスにリクエストヘッダや送信元IP、フォームの入力値などが入っている
          */
         $folder->title = $request->title;
-        // インスタンスの状態をデータベースへ書き込む
-        $folder->save();
+
+        // ユーザーに紐づけて保存
+        Auth::user()->folders()->save($folder);
+        
         /** 
          * フォルダを作成するルートに画面の出力は必要ないので、フォルダに対応するタスク一覧画面に
          * redirectメソッドを呼び出し偏移させる

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -10,6 +10,20 @@ class HomeController extends Controller
     // トップページを表示するためのコントローラーを設定する
     public function index()
     {
-        return view('home');
+        // ログインユーザーを取得する
+        $user = Auth::user();
+
+        // ログインユーザーに紐づくフォルダを一つ取得する
+        $folder = $user->folders()->first();
+
+        // 一つもフォルダを作っていない場合、ホームページを返す
+        if (is_null($folder)) {
+            return view('home');
+        }
+
+        // フォルダがあればそのフォルダのタスク一覧にリダイレクトする
+        return redirect()->route('tasks.index', [
+            'id' => $folder->id,
+        ]);
     }
 }

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -7,13 +7,14 @@ use App\Task; //Taskモデルを読み込む
 use Illuminate\Http\Request;
 use App\Http\Requests\CreateTask; // CreateTaskコントローラーをインポートする
 use App\Http\Requests\EditTask; // EditTaskコントローラーをインポートする
+use Illuminate\Support\Facades\Auth; // Authクラスをインポートする
 
 class TaskController extends Controller
 {
     public function index(int $id)
     {
-        //すべてのフォルダを取得する
-        $folders = Folder::all();
+        // ユーザーのフォルダを取得する
+        $folders = Auth::user()->folders()->get();
 
         //選択したフォルダを取得する
         $current_folder = Folder::find($id);


### PR DESCRIPTION
ログインユーザーに紐づくフォルダデータを保存できるようにするため、フォルダコントローラーを編集する。
ブラウザを確認したところ、ユーザーに紐づいたフォルダのみ表示されました。
![スクリーンショット (89)](https://user-images.githubusercontent.com/61861236/82414749-7e2dac00-9ab2-11ea-9196-4b75874fb4bf.png)
![スクリーンショット (90)](https://user-images.githubusercontent.com/61861236/82414751-7f5ed900-9ab2-11ea-9d75-828196d3812c.png)

次に、タスク一覧画面でログインユーザーに紐づくフォルダのみを表示するため、タスクコントローラーを編集する。
ブラウザを確認したところ、ユーザーに紐づいたフォルダから作成されたタスクのみ表示されました。
![スクリーンショット (91)](https://user-images.githubusercontent.com/61861236/82414933-c51ba180-9ab2-11ea-9ca9-43f24a4b4a00.png)
![スクリーンショット (92)](https://user-images.githubusercontent.com/61861236/82414942-c6e56500-9ab2-11ea-84d5-f9161a6a4232.png)

さらにHomeコントローラーを編集し、ログイン時、フォルダが作成されていればタスク一覧ページにリダイレクトし、作成していなければホームページを返す処理を実装しました。

無事、ログイン時にタスク一覧画面に遷移されることがブラウザにて確認できました。
![スクリーンショット (93)](https://user-images.githubusercontent.com/61861236/82415191-22175780-9ab3-11ea-9c3b-f9865e03f24f.png)
![スクリーンショット (94)](https://user-images.githubusercontent.com/61861236/82415199-25124800-9ab3-11ea-87c8-fedc2ec23dd0.png)

