### PR TITLE
パスワード再設定のメッセージの日本語化

### DIFF
--- a/app/Mail/ResetPassword.php
+++ b/app/Mail/ResetPassword.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class ResetPassword extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $token;
+
+    /**
+     * Create a new message instance.
+     *
+     * @param $token
+     */
+    public function __construct($token)
+    {
+        $this->token = $token;
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this
+            ->subject('パスワード再設定')
+            ->view('mail.password-reset');
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -5,6 +5,8 @@ namespace App;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use App\Mail\ResetPassword;
+use Illuminate\Support\Facades\Mail;
 
 class User extends Authenticatable
 {
@@ -44,5 +46,14 @@ class User extends Authenticatable
     public function folders()
     {
         return $this->hasMany('App\Folder');
+    }
+
+    
+    /**
+     * パスワード再設定メールを送信する
+     */
+    public function sendPasswordResetNotification($token)
+    {
+        Mail::to($this)->send(new ResetPassword($token));
     }
 }

--- a/resources/lang/jp/passwords.php
+++ b/resources/lang/jp/passwords.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Password Reset Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are the default lines which match reasons
+    | that are given by the password broker for a password update attempt
+    | has failed, such as for an invalid token or invalid new password.
+    |
+    */
+
+    'reset' => 'パスワードを再設定しました。',
+    'sent' => 'パスワード再設定リンクを送信しました。',
+    'throttled' => 'Please wait before retrying.',
+    'token' => 'トークンが無効です。',
+    'user' => "入力されたメールアドレスのユーザーは見つかりませんでした。",
+
+];

--- a/resources/lang/jp/validation.php
+++ b/resources/lang/jp/validation.php
@@ -152,6 +152,11 @@ return [
     |
     */
 
-    'attributes' => [],
+    // アプリケーション全体にattributesのキーの値を追加する
+    'attributes' => [
+        'email' => 'メールアドレス',
+        'password' => 'パスワード',
+        'token' => 'トークン',
+    ],
 
 ];

--- a/resources/views/mail/password-reset.blade.php
+++ b/resources/views/mail/password-reset.blade.php
@@ -1,0 +1,4 @@
+<!-- メールの本文のテンプレートを作成 -->
+<a href="{{ route('password.reset', ['token' => $token]) }}">
+  パスワード再設定リンク
+</a>


### PR DESCRIPTION
パスワード再設定のメッセージを日本語化するため、validation.phpのattributesのキーの値を変更する。
>cp ./resources/lang/en/passwords.php ./resources/lang/jp/

上記のコマンドで英語版のパスワード再発行メッセージを日本語のディレクトリにコピーし、日本語仕様にメッセージを変更する。
resources/views/mail/password-reset.blade.phpファイルを作成し、mailtrapに送られるパスワード再設定メールのテンプレートを作成する。

>php artisan make:mail ResetPassword

上記のコマンドでメールの送信を司る Mailable クラスのひな型を作成する。

最後にapp/User.phpファイルを編集し、パスワード再設定メール送るため、ResetPasswordクラスを作成する。

![スクリーンショット (129)](https://user-images.githubusercontent.com/61861236/84980644-96562100-b16d-11ea-9c56-fc2cabc94393.png)
![スクリーンショット (128)](https://user-images.githubusercontent.com/61861236/84980634-90f8d680-b16d-11ea-857a-46e6b6100a83.png)

ブラウザで表示したところ、無事確認できました。
