### PR TITLE
ルートモデルバインディングの実装

### DIFF
--- a/app/Http/Controllers/FolderController.php
+++ b/app/Http/Controllers/FolderController.php
@@ -40,9 +40,10 @@ class FolderController extends Controller
         /** 
          * フォルダを作成するルートに画面の出力は必要ないので、フォルダに対応するタスク一覧画面に
          * redirectメソッドを呼び出し偏移させる
+         * idからfolderに変更し、routeのパラメーターに対応させる
          */
         return redirect()->route('tasks.index', [
-            'id' => $folder->id,
+            'folder' => $folder->id,
         ]);
     }
 }

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -11,77 +11,88 @@ use Illuminate\Support\Facades\Auth; // Authクラスをインポートする
 
 class TaskController extends Controller
 {
-    public function index(int $id)
+    /**
+     * idからfolderを受け取るよう記述しなおすことで、URL中のIDに該当するフォルダデータが
+     * コントローラーメソッド渡される 
+     * @param Folder $folder
+     * @return \Illuminate\View\View
+     */ 
+    public function index(Folder $folder)
     {
+
+        if (Auth::user()->id !== $folder->user_id) {
+            abort(403);
+        }
+        
         // ユーザーのフォルダを取得する
         $folders = Auth::user()->folders()->get();
 
-        //選択したフォルダを取得する
-        $current_folder = Folder::find($id);
-
-        //選択したフォルダに紐づかれたタスクを取得する
-        //より直感的な表現に書き換える
-        $tasks = $current_folder->tasks()->get(); 
+        // 選ばれたフォルダに紐づくタスクを取得する
+        $tasks = $folder->tasks()->get();
 
         return view('tasks/index', [
             'folders' => $folders,
             //選択したフォルダのIDを受け取り、view関数でテンプレートに渡す
-            'current_folder_id' => $current_folder->id,
+            'current_folder_id' => $folder->id,
             //選択したフォルダに紐づかれたタスクをview関数でテンプレートに渡す
             'tasks' => $tasks,
         ]);
     }
 
-    // 入力フォームを表示するためのルートを実装する 
-    public function showCreateForm(int $id) 
+    /** 
+     * 入力フォームを表示するためのルートを実装する 
+     * @param Folder $folder
+     * @return \Illuminate\View\View
+     */ 
+    public function showCreateForm(Folder $folder) 
     { 
         // URL（/folders/{id}/tasks/create）を作るためのフォルダIDをの引数で受け取る 
         return view('tasks/create', [
-             'folder_id' => $id
+             'folder_id' => $folder->id,
         ]); 
     }
 
-    // タスクを保存するcreateメソッドを追加する
-    public function create(int $id, CreateTask $request)
+    /**
+     * タスクを保存するcreateメソッドを追加する
+     * @param Folder $folder
+     * @param CreateTask $request
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function create(Folder $folder, CreateTask $request)
     {
-        // フォルダidを取得し、currrent_folderに代入する
-        $current_folder = Folder::find($id);
-
         // タスクモデルのインスタンスを作成
         $task = new Task();
         // タイトルと期限日の入力値を代入する
         $task->title = $request->title;
         $task->due_date = $request->due_date;
 
-        // current_folderに紐づくタスクを保存する
-        $current_folder->tasks()->save($task);
+        $folder->tasks()->save($task);
 
         /** 
          * タスクを作成するルートに画面の出力は必要ないので、フォルダに紐づくタスクをタスク一覧画面に
          * redirectメソッドを呼び出し偏移させる
          */
         return redirect()->route('tasks.index', [
-            'id' => $current_folder->id,
+            'id' => $folder->id,
         ]);
     }
 
-    // タスクを編集するshowEditFormメソッドを追加する
-    public function showEditForm(int $id, int $task_id)
+    /**
+     * タスクを編集するshowEditFormメソッドを追加する
+     * @param Folder $folder
+     * @param Task $task
+     * @return \Illuminate\View\View  
+     */
+    public function showEditForm(Folder $folder, Task $task)
     {
-        // 編集対象となるタスクデータを取得する
-        $task = Task::find($task_id);
-
         // タスク編集テンプレートにタスクデータを渡す
         return view('tasks/edit', [
             'task' => $task,
         ]);
     }
 
-    public function edit(int $id, int $task_id, EditTask $request)
+    public function edit(Folder $folder, Task $task, EditTask $request)
     {
-        // リクエストを受けたIDからタスクデータを取得する
-        $task = Task::find($task_id);
-
         // タイトルと期限日、状態の入力値を代入する
         $task->title = $request->title;
         $task->status = $request->status;
@@ -89,7 +100,6 @@ class TaskController extends Controller
         // タスクを保存する
         $task->save();
 
-    
         /** 
          * タスクを作成するルートに画面の出力は必要ないので、フォルダに紐づくタスクをタスク一覧画面に
          * redirectメソッドを呼び出し偏移させる

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -14,8 +14,9 @@
           </div>
           <div class="list-group">
             @foreach($folders as $folder)
+              <!-- idをfolderに変更し、パラメーターに対応させる -->
               <a 
-                href="{{ route('tasks.index', ['id' => $folder->id]) }}" 
+                href="{{ route('tasks.index', ['folder' => $folder->id]) }}" 
                 class="list-group-item {{ $current_folder_id === $folder->id ? 'active' : '' }}"
               >
                 {{ $folder->title }}
@@ -31,7 +32,8 @@
           <div class="panel-body">
             <div class="text-right">
               <!-- フォルダに紐づいたタスクのデータをコントローラーから受け取り、表示する -->
-              <a href="{{ route('tasks.create', ['id' => $current_folder_id]) }}" class="btn btn-default btn-block">
+              <!-- idをfolderに変更し、パラメーターに対応させる -->
+              <a href="{{ route('tasks.create', ['folder' => $current_folder_id]) }}" class="btn btn-default btn-block">
                 タスクを追加する
               </a>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,7 +20,8 @@ Route::group(['middleware' => 'auth'], function() {
   // トップページを表示する
   Route::get('/', 'HomeController@index')->name('home');
 
-  Route::get('/folders/{id}/tasks', 'TaskController@index')->name('tasks.index');
+  // タスク一覧のエラーの挙動をまとめて管理するルート定義を編集する
+  Route::get('/folders/{folder}/tasks', 'TaskController@index')->name('tasks.index');
 
   // フォルダ作成ページを表示する
   Route::get('/folders/create', 'FolderController@showCreateForm')->name('folders.create'); // 名前付きルートを使うことでURLを一括変更できる
@@ -28,14 +29,14 @@ Route::group(['middleware' => 'auth'], function() {
   Route::post('/folders/create', 'FolderController@create'); // 同じURLでHTTPメソッド違いのルートがいくつかある場合、どれか一つに名前をつければいい
 
   // タスク作成ページを表示する 
-  Route::get('/folders/{id}/tasks/create', 'TaskController@showCreateForm')->name('tasks.create'); 
+  Route::get('/folders/{folder}/tasks/create', 'TaskController@showCreateForm')->name('tasks.create');
   // タスク作成処理を実行する 
-  Route::post('/folders/{id}/tasks/create', 'TaskController@create');
+  Route::post('/folders/{folder}/tasks/create', 'TaskController@create');
 
   // タスク編集ページを表示する 
-  Route::get('/folders/{id}/tasks/{task_id}/edit', 'TaskController@showEditForm')->name('tasks.edit');
+  Route::get('/folders/{folder}/tasks/{task}/edit', 'TaskController@showEditForm')->name('tasks.edit');
   // タスク編集処理を実行する 
-  Route::post('/folders/{id}/tasks/{task_id}/edit', 'TaskController@edit');
+  Route::post('/folders/{folder}/tasks/{task}/edit', 'TaskController@edit');
 
   // 登録完了ページを表示する
   Route::get('/completion', 'CompletionController@index')->name('completion');


### PR DESCRIPTION
定義されていないURLにアクセスがあった場合でも適切なフィードバックを返却するため、エラーページを用意する。
TaskController.phpにabort関数を追加し、404ページを返却する。
```
 if (is_null($current_folder)) {
        abort(404);
    }
```
![スクリーンショット (130)](https://user-images.githubusercontent.com/61861236/85663637-47bc0000-b6f4-11ea-8005-6f5c3f66aef7.png)

タスクコントローラーの一つ一つのメソッドにabort関数を追加するとコードが重複してしまうため、ルートモデルバインディングを利用する。
ルートモデルバインディングによってwebアプリケーションにあるありがちな一連の処理をフレームワーク側でしてもらい、ルーティングで定義された URL から自動的にデータを取得し、モデルクラスインスタンスをコントローラーメソッドに渡すことができる。

まずタスク一覧のルーティングを定義するため、{id}の部分を{folder}に変更する。
>Route::get('/folders/{folder}/tasks', 'TaskController@index')->name('tasks.index');

次にコントローラーメソッドを編集する。
int型の$idを受け取るのではなく、Folderクラスの$folderを受け取るよう記述する。
これだけで URL 中の ID に該当するフォルダデータがコントローラーメソッドに渡され、ルートとモデルが結び付けられる。

タスク編集と作成のルートにもモデルとのバインディング機能を実装するため、ルーティングとコントローラーメソッドにもそれぞれ同じように編集を加える。

ここでブラウザで確認したところ、フォルダ作成する際にタスク一覧ページへのリダイレクト機能が動かないなど、エラーが出ました。
どうやらこれに関しては参考サイトの記事の情報が古く、5.8まではこれでも動いてたものが6.0で修正ようで、FolderControllerなどのkeyの指定が間違っていて、{folder}がroute()のパラメータに対応してるということで、'id'の部分を'folder'に編集いたしました。
ほかにもindex.blade.phpのhref属性のキーの部分を'id'から'fokder'にすべて変更し、無事エラーが解決いたしました。

最後にログインユーザーの ID とフォルダの user_id カラムの値を比較し、一致しなければログインユーザーはそのフォルダとは紐づいていないため、閲覧する権限がないということで abort(403) を返却するため、タスクコントローラーを編集する。
```
if (Auth::user()->id !== $folder->user_id) {
        abort(403);
    }
```
![スクリーンショット (131)](https://user-images.githubusercontent.com/61861236/85665401-54d9ee80-b6f6-11ea-8943-5e6bd79e4e91.png)

ブラウザで表示したところ、しっかりとすべての機能が動くことを確認できました。