### PR TITLE
ポリシークラスの作成

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -23,7 +23,7 @@ class HomeController extends Controller
 
         // フォルダがあればそのフォルダのタスク一覧にリダイレクトする
         return redirect()->route('tasks.index', [
-            'id' => $folder->id,
+            'folder' => $folder->id,
         ]);
     }
 }

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -19,11 +19,6 @@ class TaskController extends Controller
      */ 
     public function index(Folder $folder)
     {
-
-        if (Auth::user()->id !== $folder->user_id) {
-            abort(403);
-        }
-        
         // ユーザーのフォルダを取得する
         $folders = Auth::user()->folders()->get();
 
@@ -73,7 +68,7 @@ class TaskController extends Controller
          * redirectメソッドを呼び出し偏移させる
          */
         return redirect()->route('tasks.index', [
-            'id' => $folder->id,
+            'folder' => $folder->id,
         ]);
     }
 
@@ -91,6 +86,13 @@ class TaskController extends Controller
         ]);
     }
 
+    /**
+     * タスク編集
+     * @param Folder $folder
+     * @param Task $task
+     * @param EditTask $request
+     * @return \Illuminate\Http\RedirectResponse
+     */
     public function edit(Folder $folder, Task $task, EditTask $request)
     {
         // タイトルと期限日、状態の入力値を代入する
@@ -105,7 +107,7 @@ class TaskController extends Controller
          * redirectメソッドを呼び出し偏移させる
          */
         return redirect()->route('tasks.index', [
-            'id' => $task->folder_id,
+            'folder' => $task->folder_id,
         ]);
     }
 }

--- a/app/Policies/FolderPolicy.php
+++ b/app/Policies/FolderPolicy.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Policies;
+
+use App\User;
+use App\Folder;
+
+class FolderPolicy
+{
+    /**
+     * フォルダの閲覧権限
+     * @param User $user
+     * @param Folder $folder
+     * @return bool
+     */
+    public function view(User $user, Folder $folder)
+    {
+        return $user->id === $folder->user_id;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -4,6 +4,8 @@ namespace App\Providers;
 
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Gate;
+use App\Folder;
+use App\Policies\FolderPolicy; 
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -13,7 +15,7 @@ class AuthServiceProvider extends ServiceProvider
      * @var array
      */
     protected $policies = [
-        // 'App\Model' => 'App\Policies\ModelPolicy',
+        Folder::class => FolderPolicy::class,
     ];
 
     /**

--- a/resources/views/tasks/create.blade.php
+++ b/resources/views/tasks/create.blade.php
@@ -24,7 +24,7 @@
               </div>
             @endif
             <!-- formアクションでurlを呼び出し、フォームを使ってデータを送る -->
-            <form action="{{ route('tasks.create', ['id' => $folder_id]) }}" method="POST">
+            <form action="{{ route('tasks.create', ['folder' => $folder_id]) }}" method="POST">
               <!-- 他サイトからの悪意あるPOSTリクエストを受け付けないよう、自分のサイトからのPOSTリクエストだけ受け付けるため、CSRFトークンを用いる -->
               @csrf
               <div class="form-group">

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -22,7 +22,7 @@
               </div>
             @endif
             <form
-                action="{{ route('tasks.edit', ['id' => $task->folder_id, 'task_id' => $task->id]) }}"
+                action="{{ route('tasks.edit', ['folder' => $task->folder_id, 'task' => $task->id]) }}"
                 method="POST"
             >
               @csrf

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -63,7 +63,7 @@
                   <td>{{ $task->formatted_due_date }}</td>
                   <td>
                     <!-- タスク一覧画面への編集リンク -->
-                    <a href="{{ route('tasks.edit', ['id' => $task->folder_id, 'task_id' => $task->id]) }}">
+                    <a href="{{ route('tasks.edit', ['folder' => $task->folder_id, 'task' => $task->id]) }}">
                         編集
                     </a>
                   </td>

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,23 +20,27 @@ Route::group(['middleware' => 'auth'], function() {
   // トップページを表示する
   Route::get('/', 'HomeController@index')->name('home');
 
-  // タスク一覧のエラーの挙動をまとめて管理するルート定義を編集する
-  Route::get('/folders/{folder}/tasks', 'TaskController@index')->name('tasks.index');
-
   // フォルダ作成ページを表示する
   Route::get('/folders/create', 'FolderController@showCreateForm')->name('folders.create'); // 名前付きルートを使うことでURLを一括変更できる
   // フォルダ作成処理を実行する
   Route::post('/folders/create', 'FolderController@create'); // 同じURLでHTTPメソッド違いのルートがいくつかある場合、どれか一つに名前をつければいい
 
-  // タスク作成ページを表示する 
-  Route::get('/folders/{folder}/tasks/create', 'TaskController@showCreateForm')->name('tasks.create');
-  // タスク作成処理を実行する 
-  Route::post('/folders/{folder}/tasks/create', 'TaskController@create');
+  Route::group(['middleware' => 'can:view,folder'], function() {
 
-  // タスク編集ページを表示する 
-  Route::get('/folders/{folder}/tasks/{task}/edit', 'TaskController@showEditForm')->name('tasks.edit');
-  // タスク編集処理を実行する 
-  Route::post('/folders/{folder}/tasks/{task}/edit', 'TaskController@edit');
+    // タスク一覧のエラーの挙動をまとめて管理するルート定義を編集する
+    Route::get('/folders/{folder}/tasks', 'TaskController@index')->name('tasks.index');
+
+    // タスク作成ページを表示する 
+    Route::get('/folders/{folder}/tasks/create', 'TaskController@showCreateForm')->name('tasks.create');
+    // タスク作成処理を実行する 
+    Route::post('/folders/{folder}/tasks/create', 'TaskController@create');
+
+    // タスク編集ページを表示する 
+    Route::get('/folders/{folder}/tasks/{task}/edit', 'TaskController@showEditForm')->name('tasks.edit');
+    // タスク編集処理を実行する 
+    Route::post('/folders/{folder}/tasks/{task}/edit', 'TaskController@edit');
+    
+  }); 
 
   // 登録完了ページを表示する
   Route::get('/completion', 'CompletionController@index')->name('completion');


### PR DESCRIPTION
>php artisan make:policy FolderPolicy

上記のコマンドで、ユーザーの持つ権限にしたがって特定の処理を許可するか判断するため、ポリシークラスを作成する。

作成したFolderPolicy.phpを編集し、ユーザーとフォルダが紐づいているときのみ許可する意味の処理を定義する。

ポリシーとモデルクラスを紐づけるため、AuthServiceProvider.phpを編集する。

ポリシーをミドルウェアを介して使用するため、web.phpを編集する。

```
Route::group(['middleware' => 'can:view,folder'], function() {
    Route::get('/folders/{folder}/tasks', 'TaskController@index')->name('tasks.index');
});
```

これにより認可処理が true を返せばそのまま後続処理に移り、false を返せば処理を中断してコード 403 でレスポンスする。
Folder モデルからFolderPolicy ポリシーの view メソッドが認可に使用されることになり、view メソッドで定義された「ユーザーとフォルダが紐づいているときのみ許可する」という認可処理が実行される。

ブラウザで確認したところ、無事ユーザーと紐づいていないフォルダを開くと、403エラーが表示されました。

![スクリーンショット (134)](https://user-images.githubusercontent.com/61861236/86213190-4d15c080-bbb4-11ea-8f63-4f43dd8f8a78.png)
![スクリーンショット (135)](https://user-images.githubusercontent.com/61861236/86213197-5010b100-bbb4-11ea-8e9d-adafc179419c.png)

なお、タスクの作成や編集処理を行おうとしたところ、前回と同様のテンプレートのエラーが起こりました。
>Missing required parameters for [Route: tasks.edit] [URI: folders/{folder}/tasks/{task}/edit]. 

エラーで検索をかけましたが参考になりそうな記事が見当たらず、バージョンの違いから起こるエラーなのか分かりませんでしたが、試しにテンプレートの
> a href="{{ route('tasks.edit', ['folder' => $task->folder_id, 'task_id' => $task->id]) }}"

のtask_idの部分をtaskに変えたところ、エラーが解消されたので、その他のテンプレートを含めすべてのtask_idの箇所をtaskに変更いたしました。